### PR TITLE
Prevent OAuth users from logging in with email and password

### DIFF
--- a/domain/errors.go
+++ b/domain/errors.go
@@ -14,16 +14,16 @@ var (
 	ErrNoCommentChangesMade = errors.New("no changes were made to the comment")
 
 	// Usecase-Specific Errors
-	ErrBlogRequired      = errors.New("blog cannot be nil")
-	ErrEmptyTitle        = errors.New("title is required")
-	ErrEmptyContent      = errors.New("content is required")
-	ErrInvalidUserID     = errors.New("user_id is required")
-	ErrBlogIDRequired    = errors.New("blog ID is required")
+	ErrBlogRequired   = errors.New("blog cannot be nil")
+	ErrEmptyTitle     = errors.New("title is required")
+	ErrEmptyContent   = errors.New("content is required")
+	ErrInvalidUserID  = errors.New("user_id is required")
+	ErrBlogIDRequired = errors.New("blog ID is required")
 
 	// Comment Usecase-Specific Errors
-	ErrCommentRequired   = errors.New("comment cannot be nil")
+	ErrCommentRequired     = errors.New("comment cannot be nil")
 	ErrEmptyCommentContent = errors.New("comment content is required")
-	ErrCommentIDRequired = errors.New("comment ID is required")
+	ErrCommentIDRequired   = errors.New("comment ID is required")
 
 	// Repository-Specific Errors
 	ErrInsertingDocuments  = errors.New("failed to insert document(s)")
@@ -33,18 +33,16 @@ var (
 	ErrDeletingDocument    = errors.New("failed to delete document")
 	ErrCursorIteration     = errors.New("database cursor iteration error")
 
-
-	
 	// User-Specific Errors
-	ErrInvalidEmailFormat      = errors.New("invalid email format")
-    ErrEmailAlreadyExists      = errors.New("email already exists")
-    ErrUserNotFound            = errors.New("user not found")
-    ErrInvalidCredentials      = errors.New("invalid credentials")
-    ErrEmailNotVerified        = errors.New("email not verified")
-    ErrPasswordHashingFailed   = errors.New("password hashing failed")
-    ErrTokenGenerationFailed   = errors.New("token generation failed")
-    ErrEmailSendingFailed      = errors.New("email sending failed")
-    ErrUserCreationFailed      = errors.New("user creation failed")
-    ErrDatabaseOperationFailed = errors.New("database operation failed")
-
+	ErrInvalidEmailFormat               = errors.New("invalid email format")
+	ErrEmailAlreadyExists               = errors.New("email already exists")
+	ErrUserNotFound                     = errors.New("user not found")
+	ErrInvalidCredentials               = errors.New("invalid credentials")
+	ErrEmailNotVerified                 = errors.New("email not verified")
+	ErrPasswordHashingFailed            = errors.New("password hashing failed")
+	ErrTokenGenerationFailed            = errors.New("token generation failed")
+	ErrEmailSendingFailed               = errors.New("email sending failed")
+	ErrUserCreationFailed               = errors.New("user creation failed")
+	ErrDatabaseOperationFailed          = errors.New("database operation failed")
+	ErrOAuthUserCannotLoginWithPassword = errors.New("OAuth user cannot login with password")
 )


### PR DESCRIPTION
- Added check to disallow login for users registered via OAuth (Google, GitHub, Facebook)
- Ensured only users with stored passwords can authenticate via traditional login
- Introduced error: ErrOAuthUserCannotLoginWithPassword