### PR TITLE
Remove Duplicate Forgot Password Logic in Favor of Reset Password Flow

### DIFF
--- a/delivery/controllers/auth_controller.go
+++ b/delivery/controllers/auth_controller.go
@@ -122,41 +122,6 @@ func (ac *AuthController) Login(c *gin.Context) {
 	})
 }
 
-// forgot password controller
-func (au *AuthController) ForgotPassword(c *gin.Context) {
-	ctx := c.Request.Context()
-
-	var input struct {
-		Email string `json:"email" binding:"required,email"`
-	}
-
-	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error":   "Invalid request body",
-			"details": err.Error(),
-		})
-		return
-	}
-
-	if err := au.AuthUsecase.ForgotPassword(ctx, input.Email); err != nil {
-		switch {
-		case errors.Is(err, domain.ErrInvalidEmailFormat):
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid email format"})
-		case errors.Is(err, domain.ErrUserNotFound):
-			c.JSON(http.StatusNotFound, gin.H{"error": "User not found"})
-		case errors.Is(err, domain.ErrTokenGenerationFailed):
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate reset token"})
-		default:
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Password reset request failed", "details": err.Error()})
-		}
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"message": "Password reset email sent if the email exists in our system",
-	})
-}
-
 
 // ChangePassword handles password change requests.
 // It requires the user to be authenticated and to provide the old and new passwords.

--- a/domain/auth.go
+++ b/domain/auth.go
@@ -45,9 +45,6 @@ type IAuthUsecase interface {
 	// ChangePassword allows an authenticated user to change their password by
 	// verifying the old password and updating with the new one.
 	ChangePassword(ctx context.Context, userID, oldPassword, newPassword string) error
-
-	// ForgotPassword allows user not logged in and has forgotten their password to reset password via email
-	ForgotPassword(ctx context.Context, email string) error	
 }
 
 //PasswordService Interface

--- a/usecases/auth_usecase.go
+++ b/usecases/auth_usecase.go
@@ -475,50 +475,6 @@ func (uc *AuthUseCase) ChangePassword(ctx context.Context, userID string, oldPas
 }
 
 
-//forgot password
-func (auc *AuthUseCase) ForgotPassword(ctx context.Context, email string) error {
-	if !validateEmail(email) {
-		return fmt.Errorf("%w", domain.ErrInvalidEmailFormat)
-	}
-
-	user, err := auc.UserRepo.FindByEmail(ctx, email)
-	if err != nil {
-		return fmt.Errorf("%w:%v", domain.ErrUserNotFound, err)
-
-	}
-	//generate a reset token
-	resetToken, err := auc.JWTService.GeneratePasswordResetToken(fmt.Sprint(user.UserID))
-	if err != nil {
-		return fmt.Errorf("%w: %v", domain.ErrTokenGenerationFailed, err)
-
-	}
-	//reset link
-	resetLink := fmt.Sprintf("%s/reset-password?token=%s", auc.BaseURL, resetToken)
-
-	emailBody := fmt.Sprintf(`
-    <html>
-      <body style="font-family: Arial, sans-serif; line-height: 1.6;">
-        <h2>Password Reset Requested</h2>
-        <p>We received a request to reset your password. Click the link below to proceed. This link is one-time use and expires soon.</p>
-        <p>
-          <a href="%s" style="display: inline-block; padding: 10px 20px; background-color: #f39c12;
-          color: white; text-decoration: none; border-radius: 4px;">Reset Password</a>
-        </p>
-        <p>If you didn't request this, you can safely ignore this email.</p>
-        <p>— The Team</p>
-      </body>
-    </html>
-    `, resetLink)
-
-	if err := auc.NotificationService.SendEmail(user.Email, "reset your password", emailBody); err != nil {
-		fmt.Println("forgot password email send failed", err)
-
-	}
-	return nil
-
-}
-
-
 //function to validate email
 
 func validateEmail(email string) bool {


### PR DESCRIPTION
This PR removes the redundant ForgotPassword logic from the usecase, controller, and IAuthUsecase interface after identifying it overlaps with the existing ResetPassword implementation.