### PR TITLE
Implement User Role Promotion and Demotion Feature (Admin Only)

### DIFF
--- a/delivery/controllers/user_controller.go
+++ b/delivery/controllers/user_controller.go
@@ -13,6 +13,7 @@ type UserController struct {
 	userUseCase domain.IUserUseCase      // user usecase for user operations
 }
 
+// user promote to admin role controller
 func (uc *UserController) PromoteToAdmin(c *gin.Context) {
 	userID := c.Param("id")
 
@@ -32,3 +33,23 @@ func (uc *UserController) PromoteToAdmin(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "User promoted to admin successfully"})
 }
 
+
+// user demote from admin role controller
+func (uc *UserController) DemoteFromAdmin(c *gin.Context) {
+	userID := c.Param("id")
+
+	err := uc.userUseCase.DemoteFromAdmin(c.Request.Context(), userID)
+	if err != nil {
+		switch err {
+		case domain.ErrInvalidUserID, domain.ErrInvalidRole:
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		case domain.ErrUserNotFound:
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "User demoted to regular user successfully"})
+}

--- a/delivery/controllers/user_controller.go
+++ b/delivery/controllers/user_controller.go
@@ -2,11 +2,33 @@ package controllers
 
 // imports
 import (
+	"net/http"
+
 	"github.com/InkForge/Blog_Website/domain"
+	"github.com/gin-gonic/gin"
 )
 
 // user controller
 type UserController struct {
 	userUseCase domain.IUserUseCase      // user usecase for user operations
+}
+
+func (uc *UserController) PromoteToAdmin(c *gin.Context) {
+	userID := c.Param("id")
+
+	err := uc.userUseCase.PromoteToAdmin(c.Request.Context(), userID)
+	if err != nil {
+		switch err {
+		case domain.ErrInvalidUserID, domain.ErrInvalidRole:
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		case domain.ErrUserNotFound:
+			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "User promoted to admin successfully"})
 }
 

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -78,7 +78,7 @@ var (
     ErrUserVerified            = errors.New("user already verified")
 	ErrGetTokenExpiryFailed =errors.New("failed to get token expiration time")
 	ErrWeakPassword         = errors.New("password is too weak")
-
+	ErrInvalidRole          = errors.New("invalid role specified")
 
 	// ─── Generic Errors ────────────────────────────────────────────────────
 	ErrInternalServerError = errors.New("internal server error")

--- a/domain/user.go
+++ b/domain/user.go
@@ -52,7 +52,8 @@ type IUserRepository interface {
 
 	GetAllUsers( c context.Context)([]User,error)
 	SearchUsers( c context.Context,q string)([]User,error)
-
+	
+	UpdateRole( c context.Context, userID string, role string) error
 }
 
 // user usecase interface

--- a/domain/user.go
+++ b/domain/user.go
@@ -61,11 +61,9 @@ type IUserUseCase interface {
 	GetUserByID(c context.Context,userID string)(User,error)
 	GetUsers(c context.Context)([]User,error)
 	DeleteUserByID(c context.Context,userID string)(error)
-	PromoteUser(c context.Context,userID string)(error)
-	DemoteUser(c context.Context,userID string)(error)
 	SearchUsers(c context.Context,q string)([]User,error)
 	GetMyData(c context.Context,userID string)(*User,error)
 	UpdateProfile(c context.Context ,user *User)(error)
-
+	PromoteToAdmin(c context.Context, userID string) error
 	
 }

--- a/domain/user.go
+++ b/domain/user.go
@@ -65,5 +65,6 @@ type IUserUseCase interface {
 	GetMyData(c context.Context,userID string)(*User,error)
 	UpdateProfile(c context.Context ,user *User)(error)
 	PromoteToAdmin(c context.Context, userID string) error
+	DemoteFromAdmin(ctx context.Context, userID string) error
 	
 }

--- a/repositories/user_repository.go
+++ b/repositories/user_repository.go
@@ -234,6 +234,35 @@ func (ur *UserRepository) UpdateTokens(ctx context.Context, userID string, acces
 	return nil
 }
 
+// UpdateRole updates the role of a user. Only "admin" or "user" roles are allowed.
+func (ur *UserRepository) UpdateRole(ctx context.Context, userID string, role string) error {
+	if role != "admin" && role != "user" {
+		return domain.ErrInvalidRole
+	}
+
+	objID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return domain.ErrInvalidUserID
+	}
+
+	result, err := ur.userCollection.UpdateOne(
+		ctx,
+		bson.M{"_id": objID},
+		bson.M{"$set": bson.M{"role": role}},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	if result.MatchedCount == 0 {
+		return domain.ErrUserNotFound
+	}
+
+	return nil
+}
+
+
 
 
 

--- a/usecases/user_usecase.go
+++ b/usecases/user_usecase.go
@@ -98,5 +98,22 @@ func (uc *UserUseCase) PromoteToAdmin(ctx context.Context, userID string) error 
 	return uc.UserRepo.UpdateRole(ctx, userID, "admin")
 }
 
+func (uc *UserUseCase) DemoteFromAdmin(ctx context.Context, userID string) error {
+	if userID == "" {
+		return domain.ErrInvalidUserID
+	}
+
+	// check if user exists
+	_, err := uc.UserRepo.FindByID(ctx, userID)
+	if err != nil {
+		return err
+	}
+
+	// demote to user
+	return uc.UserRepo.UpdateRole(ctx, userID, "user")
+}
+
+
+
 
 

--- a/usecases/user_usecase.go
+++ b/usecases/user_usecase.go
@@ -82,12 +82,20 @@ func (uc *UserUseCase)UpdateProfile(ctx context.Context,user *domain.User)(error
 	return uc.UserRepo.UpdateUser(ctx,user)
 
 }
-//promote user and demote user are not implemented yet
-func(uc *UserUseCase)PromoteUser(ctx context.Context,userID string)(error){
-	return nil
-}
-func(uc *UserUseCase)DemoteUser(ctx context.Context,userID  string)(error){
-	return nil
+
+func (uc *UserUseCase) PromoteToAdmin(ctx context.Context, userID string) error {
+	if userID == "" {
+		return domain.ErrInvalidUserID
+	}
+
+	// check if user exists
+	_, err := uc.UserRepo.FindByID(ctx, userID)
+	if err != nil {
+		return err
+	}
+
+	// promote to admin
+	return uc.UserRepo.UpdateRole(ctx, userID, "admin")
 }
 
 


### PR DESCRIPTION
This PR introduces the ability for admins to promote users to admin and demote them back to regular users. It touches the repository, use case, controller, and domain layers while adhering to Clean Architecture principles.

- Features Implemented:

1. **Repository Layer**
   - Added `UpdateRole(ctx, userID, role)` method to `UserRepository`
   - Role validation (`"admin"` or `"user"`) with `ErrInvalidRole` handling
   - Returns proper domain-level errors: `ErrInvalidUserID`, `ErrInvalidRole`, `ErrUserNotFound`
   - Updated `UserRepository` interface to include new method

2. **Use Case Layer**
   - `PromoteToAdmin(ctx, userID)`:
     - Validates user existence
     - Updates role to `"admin"`
   - `DemoteFromAdmin(ctx, userID)`:
     - Validates user existence
     - Updates role to `"user"`

3. **Controller Layer**
   - `PromoteToAdmin(c *gin.Context)`:
     - Extracts `userID` from URL
     - Invokes use case
     - Handles and returns appropriate status codes
   - `DemoteFromAdmin(c *gin.Context)`:
     - Same flow, demotes to `"user"`

4. **Domain Errors**
   - Introduced `ErrInvalidRole` in `domain/errors.go` for clean error propagation