### PR TITLE
Add centralized MongoDB client and init UserRepository in main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 config.env
+.env
 Makefile

--- a/delivery/main.go
+++ b/delivery/main.go
@@ -1,1 +1,16 @@
 package main
+
+import (
+	"github.com/InkForge/Blog_Website/infrastructures/db/mongo"
+	"github.com/InkForge/Blog_Website/repositories"
+)
+
+func main() {
+	client := mongo.NewMongoClient()
+	db := client.Database("blogapp")
+
+	userRepo := repositories.NewUserRepository(db)
+	
+	// other repo defined here as the above one
+
+}

--- a/infrastructures/config.go
+++ b/infrastructures/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	DBPassword string
 	DBName     string
 	DBDriver   string
+	DBUri      string
 
 	JWTSecretKey              string
 	JWTExpirationMinutes      int
@@ -70,6 +71,7 @@ func LoadConfig() (*Config, error) {
 		DBUser:     viper.GetString("DB_USER"),
 		DBPassword: viper.GetString("DB_PASSWORD"),
 		DBName:     viper.GetString("DB_NAME"),
+		DBUri:      viper.GetString("DB_URI"),
 
 		JWTSecretKey:              viper.GetString("JWT_SECRET_KEY"),
 		JWTExpirationMinutes:      viper.GetInt("JWT_EXPIRATION_MINUTES"),

--- a/infrastructures/db/mongo/client.go
+++ b/infrastructures/db/mongo/client.go
@@ -1,0 +1,30 @@
+package mongo
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/InkForge/Blog_Website/infrastructures"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func NewMongoClient() *mongo.Client {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// load configuration
+	cfg, err := infrastructures.LoadConfig()
+	if err != nil {
+		log.Fatalf("Failed to load config: %v", err)
+	}
+
+	// connect to MongoDB using the URI from config
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(cfg.DBUri))
+	if err != nil {
+		log.Fatalf("Mongo connection error: %v", err)
+	}
+
+	return client
+}


### PR DESCRIPTION
- Centralized MongoDB client setup using LoadConfig
- Loaded Mongo URI from env
- Initialized UserRepository in main.go with injected collection
- Reduced code duplication across repositories