### PR TITLE
Remove duplicate custom errors from errors.go

### DIFF
--- a/domain/errors.go
+++ b/domain/errors.go
@@ -74,8 +74,6 @@ var (
 	ErrUserUpdateFailed                 = errors.New("user update failed")
 	ErrEmailVerficationFailed           = errors.New("email verification failed")
 	ErrTokenVerificationFailed          = errors.New("token verification failed")
-	ErrInvalidRole                      = errors.New("invalid role")
-	ErrWeakPassword                     = errors.New("weak password")
 	ErrPasswordMismatch                 = errors.New("passwords do not match")
 	ErrUserVerified                     = errors.New("user already verified")
 	ErrGetTokenExpiryFailed             = errors.New("failed to get token expiration time")


### PR DESCRIPTION
- ErrWeakPassword and ErrInvalidRole repeated causing error.            